### PR TITLE
lock videojs version

### DIFF
--- a/blueprints/ivy-videojs/index.js
+++ b/blueprints/ivy-videojs/index.js
@@ -2,7 +2,7 @@ module.exports = {
   description: 'ivy-videojs',
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('video.js', '~5.0.0-29');
+    return this.addBowerPackageToProject('video.js', '5.0.0-29');
   },
 
   normalizeEntityName: function() {

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "bootstrap": "~3.3.4",
-    "video.js": "~5.0.0-29",
+    "video.js": "5.0.0-29",
     "qunit": "~1.17.1"
   }
 }


### PR DESCRIPTION
With the recent update of `videojs` i'm getting this error running `ember s`
```
ENOENT, no such file or directory '/path/to/app/tmp/tree_merger-tmp_dest_dir-n6tA7LOM.tmp/bower_components/video.js/dist/node_modules/global/document.js'
Error: ENOENT, no such file or directory '/path/to/app/tmp/tree_merger-tmp_dest_dir-n6tA7LOM.tmp/bower_components/video.js/dist/node_modules/global/document.js'
    at Error (native)
    at Object.fs.openSync (fs.js:500:18)
    at Object.fs.readFileSync (fs.js:352:15)
    at SourceMap.<anonymous> (/path/to/app/node_modules/ember-cli/node_modules/broccoli-sourcemap-concat/node_modules/fast-sourcemap-concat/lib/source-map.js:268:17)
```
I think quick and acceptable solution for now would be locking working version of videojs. Thanks.