### PR TITLE
Upgrade to videojs 5.0.0-rc.101.

### DIFF
--- a/blueprints/ivy-videojs/index.js
+++ b/blueprints/ivy-videojs/index.js
@@ -2,7 +2,7 @@ module.exports = {
   description: 'ivy-videojs',
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('video.js', '5.0.0-29');
+    return this.addBowerPackageToProject('video.js', '5.0.0-rc.101');
   },
 
   normalizeEntityName: function() {

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "bootstrap": "~3.3.4",
-    "video.js": "5.0.0-29",
+    "video.js": "5.0.0-rc.101",
     "qunit": "~1.17.1"
   }
 }

--- a/tests/helpers/tech-faker.js
+++ b/tests/helpers/tech-faker.js
@@ -46,6 +46,10 @@ class TechFaker extends Tech {
     return this._autoplay;
   }
 
+  controls() {
+    return false;
+  }
+
   currentTime() {
     return this._currentTime;
   }


### PR DESCRIPTION
The currently-provided [videojs 5.0.0-rc.29](https://github.com/videojs/video.js/tree/v5.0.0-rc.29) appears to have issues with iOS devices. It looks as though the videos often fail to play inline and only display the video when played back at full screen.

Upgrading to the current RC (5.0.0-rc.101) appears to correct the iOS issue. However, there are currently several tests failing around the TechFaker.