### PR TITLE
Fix autoplay not working on player

### DIFF
--- a/addon/templates/components/ivy-videojs.hbs
+++ b/addon/templates/components/ivy-videojs.hbs
@@ -1,5 +1,6 @@
 {{ivy-videojs-player
   abort="abort"
+  autoplay=autoplay
   canplay="canplay"
   canplaythrough="canplaythrough"
   controls=controls


### PR DESCRIPTION
Setting `autoplay=true` is not working on the player at the moment because it's missing from this template. Restoring this line make autoplay work again.