### PR TITLE
Upgrade to Ember CLI 2.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes Bower's cache
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ivy-videojs",
   "dependencies": {
-    "ember": "~2.9.0",
+    "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3",
     "video.js": "~5.12",
     "bootstrap": "~3.3.4"

--- a/package.json
+++ b/package.json
@@ -2,32 +2,38 @@
   "name": "ivy-videojs",
   "version": "0.6.4",
   "description": "A set of Ember components for the video.js HTML5 video player.",
+  "keywords": [
+    "ember-addon",
+    "video",
+    "videojs"
+  ],
+  "license": "MIT",
+  "author": "Dray Lacy",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "https://github.com/IvyApp/ivy-videojs",
   "scripts": {
     "build": "ember build",
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -",
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "https://github.com/IvyApp/ivy-videojs",
-  "engines": {
-    "node": ">= 0.10.0"
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.0.10"
   },
-  "author": "Dray Lacy",
-  "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "2.9.1",
+    "ember-cli": "2.10.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-github-pages": "0.1.2",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-jshint": "^1.0.4",
+    "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
@@ -39,14 +45,8 @@
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.10"
   },
-  "keywords": [
-    "ember-addon",
-    "video",
-    "videojs"
-  ],
-  "dependencies": {
-    "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.0.10"
+  "engines": {
+    "node": ">= 0.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This doesn't involve any changes to `ivy-videojs` itself, it's just an upgrade to `ember-cli` and `ember` in the dummy app.