### PR TITLE
Add demoURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "node": ">= 0.12.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://ivyapp.github.io/ivy-videojs/"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".