### PR TITLE
Fix autoplay not working on player

### DIFF
--- a/addon/templates/components/ivy-videojs.hbs
+++ b/addon/templates/components/ivy-videojs.hbs
@@ -1,5 +1,6 @@
 {{ivy-videojs-player
   abort=(action "abort")
+  autoplay=autoplay
   canplay=(action "canplay")
   canplaythrough=(action "canplaythrough")
   controls=controls


### PR DESCRIPTION
Setting `autoplay=true` is not working on the player at the moment because it's missing from this template. Restoring this line make autoplay work again.
# Conflicts:
#	addon/templates/components/ivy-videojs.hbs